### PR TITLE
Change default julia exe location

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+Manifest.toml

--- a/src/Malt.jl
+++ b/src/Malt.jl
@@ -44,7 +44,7 @@ function Worker(;exeflags=[])
     Worker(port, proc)
 end
 
-function _get_worker_cmd(exe="julia"; exeflags=[])
+function _get_worker_cmd(exe=joinpath(Sys.BINDIR, Base.julia_exename()); exeflags=[])
     script = @__DIR__() * "/worker.jl"
     # TODO: Project environment
     `$exe $exeflags $script`


### PR DESCRIPTION
Taken from the `Base.julia_cmd()` implementation.

And add `Manifest.toml` to `.gitignore`.