### PR TITLE
Improve handling of remote exceptions

### DIFF
--- a/src/Malt.jl
+++ b/src/Malt.jl
@@ -92,9 +92,15 @@ end
 # This is not a problem when using Pluto, since Pluto itself handles exceptions.
 function _promise(socket)
     @async begin
-        response = deserialize(socket)
-        close(socket)
-        response.result
+        # Close socket even if there's a serialization exception
+        try
+            response = deserialize(socket)
+            response.result
+        catch e
+            rethrow(e)
+        finally
+            close(socket)
+        end
     end
 end
 

--- a/src/Malt.jl
+++ b/src/Malt.jl
@@ -81,15 +81,7 @@ function _send_msg(port::UInt16, msg)
     return socket
 end
 
-# FIXME:
-# `response.result` can be the result of a computation, or an Exception.
-# If it's an exception defined in Base, we could rethrow it here.
-# but what should be done if it's an exception that's NOT defined in Base?
-#
-# Also, these exceptions are wrapped in a `TaskFailedException`,
-# which seems kind of ugly. How to unwrap them?
-#
-# This is not a problem when using Pluto, since Pluto itself handles exceptions.
+# TODO: Unwrap TaskFailedExceptions
 function _promise(socket)
     @async begin
         # Close socket even if there's a serialization exception

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -78,3 +78,69 @@ end
     @test m.isrunning(w) === false
 end
 
+@testset "Exceptions" begin
+    w = m.Worker()
+
+
+    ## Mutually Known errors are not thrown, but returned as values.
+
+    result = m.remote_eval_fetch(w, quote
+        sqrt(-1)
+    end)
+    @test result isa DomainError
+
+    result2 = m.remote_eval_fetch(w, quote
+        error("Julia stack traces are bad. GL 😉")
+    end)
+    @test result2 isa ErrorException
+
+
+    ## Serializing values of unknown types will cause an exception.
+
+    stub_type_name = gensym(:NonLocalType)
+
+    m.remote_eval_wait(w, quote
+        struct $(stub_type_name) end
+    end)
+
+    @test_throws(TaskFailedException,
+        m.remote_eval_fetch(w, quote
+            $stub_type_name()
+        end),
+    )
+
+
+    ## Throwing unknown exceptions will definitely cause an exception.
+
+    stub_type_name2 = gensym(:NonLocalException)
+
+    m.remote_eval_wait(w, quote
+        struct $stub_type_name2 <: Exception end
+    end)
+
+    @test_throws(TaskFailedException,
+        m.remote_eval_fetch(w, quote
+            throw($stub_type_name2())
+        end),
+    )
+
+
+    ## Catching unknown exceptions and returning them as values also causes an exception.
+    ## (just like any other unknown type).
+
+    @test_throws(TaskFailedException,
+        m.remote_eval_fetch(w, quote
+            try
+                throw($stub_type_name2())
+            catch e
+                e
+            end
+        end),
+    )
+
+
+    # The worker should be able to handle all that throwing
+    @test m.isrunning(w)
+
+    m.stop(w)
+end


### PR DESCRIPTION
- Handle serialization exceptions
- Add tests for worker thrown exceptions

Closes #9