### PR TITLE
Reduce overhead for sync calls and message allocation

### DIFF
--- a/src/Malt.jl
+++ b/src/Malt.jl
@@ -61,18 +61,22 @@ end
 
 _new_call_msg(send_result::Bool, f::Function, args...; kwargs...) = (
     header = :call,
-    body = (f=f, args=args, kwargs=kwargs),
+    f=f,
+    args=args,
+    kwargs=kwargs,
     send_result = send_result,
 )
 
 _new_do_msg(f::Function, args...; kwargs...) = (
     header = :remote_do,
-    body = (f=f, args=args, kwargs=kwargs),
+    f=f,
+    args=args,
+    kwargs=kwargs,
 )
 
 _new_channel_msg(expr) = (
     header = :channel,
-    body = expr,
+    expr = expr,
 )
 
 function _send_msg(port::UInt16, msg)

--- a/src/worker.jl
+++ b/src/worker.jl
@@ -51,9 +51,8 @@ end
 
 
 function handle(::Val{:call}, socket, msg)
-    body = msg.body # Don't use destructuring to support v1.6
     try
-        result = body.f(body.args...; body.kwargs...)
+        result = msg.f(msg.args...; msg.kwargs...)
         # @debug("Result", result)
         serialize(socket, (status=:ok, result=(msg.send_result ? result : nothing)))
     catch e
@@ -65,17 +64,15 @@ function handle(::Val{:call}, socket, msg)
 end
 
 function handle(::Val{:remote_do}, socket, msg)
-    body = msg.body
     try
-        # @debug("Remote do:", body)
-        body.f(body.args...; body.kwargs...)
+        msg.f(msg.args...; msg.kwargs...)
     finally
         close(socket)
     end
 end
 
 function handle(::Val{:channel}, socket, msg)
-    channel = eval(msg.body)
+    channel = eval(msg.expr)
     while isopen(channel) && isopen(socket)
         serialize(socket, take!(channel))
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -103,7 +103,7 @@ end
         struct $(stub_type_name) end
     end)
 
-    @test_throws(TaskFailedException,
+    @test_throws(Exception,
         m.remote_eval_fetch(w, quote
             $stub_type_name()
         end),
@@ -118,7 +118,7 @@ end
         struct $stub_type_name2 <: Exception end
     end)
 
-    @test_throws(TaskFailedException,
+    @test_throws(Exception,
         m.remote_eval_fetch(w, quote
             throw($stub_type_name2())
         end),
@@ -128,7 +128,7 @@ end
     ## Catching unknown exceptions and returning them as values also causes an exception.
     ## (just like any other unknown type).
 
-    @test_throws(TaskFailedException,
+    @test_throws(Exception,
         m.remote_eval_fetch(w, quote
             try
                 throw($stub_type_name2())


### PR DESCRIPTION
- Currently Malt creates tasks for both sync and async calls. creating and waiting for a task in a sync context creates unnecessary overhead.

- Use a flatter representation for messages (to reduce pointer indirection). This does reduce memory allocations a bit, but it's not much of an improvement compared to Distributed, which uses a lot less memory for small messages.

TODO:
- Check if using `invoke(deserialize, ...` improves type stability and allocations.
- Add performance comparison with Distributed to close #6 (currently small eval messages take about 8ms in total).
