### PR TITLE
Add benchmark to CI

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,11 +10,13 @@ Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"
 
 [compat]
-julia = "^1.6"
 RelocatableFolders = "1"
+julia = "^1.6"
 
 [extras]
+BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
+Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["Test", "Distributed", "BenchmarkTools"]

--- a/test/benchmark.jl
+++ b/test/benchmark.jl
@@ -56,8 +56,8 @@ const TEST_BENCHMARK = false
         if TEST_BENCHMARK
             @test (
                 # one of these should pass:
-                ratio < 1.2 || # < 20% slower, or
-                t1 - t2 < 0.002 # < 2ms slower
+                ratio < 1.1 || # < 10% slower, or
+                t1 - t2 < 0.001 # < 1ms slower
             )
         end
     end

--- a/test/benchmark.jl
+++ b/test/benchmark.jl
@@ -1,0 +1,66 @@
+using BenchmarkTools
+using Test
+import Malt as m
+import Distributed
+
+# Set to true to fail tests if benchmark is too slow
+const TEST_BENCHMARK = false
+
+
+@testset "Benchmark" begin
+    
+    
+    w = m.Worker()
+    @test m.isrunning(w) === true
+    
+    
+    
+    p = Distributed.addprocs(1)[1]
+    
+    
+    
+    exprs = [
+        quote
+            sum(1:100) do i
+                sum(sin.(sqrt.(1:i))) / i
+            end
+        end
+    
+        quote
+            sleep(.01)
+        end
+    
+        quote
+            1+1
+        end
+    ]
+    
+    @testset "Expr $i" for i in eachindex(exprs)
+        ex = exprs[i]
+        
+        f1() = m.remote_eval_fetch(Main, w, ex)
+        f2() = Distributed.remotecall_eval(Main, p, ex)
+        
+        f1()
+        f2()
+        
+        @test f1() ≈ f2()
+        
+        t1 = @belapsed $f1()
+        t2 = @belapsed $f2()
+        
+        ratio = t1 / t2
+        
+        @info "Expr $i" ratio t1 t2 
+        
+        if TEST_BENCHMARK
+            @test (
+                # one of these should pass:
+                ratio < 1.2 || # < 20% slower, or
+                t1 - t2 < 0.002 # < 2ms slower
+            )
+        end
+    end
+    
+    m.stop(w)
+end

--- a/test/benchmark.jl
+++ b/test/benchmark.jl
@@ -44,7 +44,7 @@ const TEST_BENCHMARK = false
         f1()
         f2()
         
-        @test f1() ≈ f2()
+        @test f1() == f2() || f1() ≈ f2()
         
         t1 = @belapsed $f1()
         t2 = @belapsed $f2()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -149,3 +149,5 @@ end
 
     m.stop(w)
 end
+
+include("benchmark.jl")


### PR DESCRIPTION
Adding a benchmark with BenchmarkTools of Distributed and Malt doing the same `remote_eval_fetch`. I also added a `@test` to ensure that these results are close enough to eachother, but I have disabled that for now, because they would fail.

Results: every `remote_eval_fetch` call has a **4ms overhead**, while Distributed has a **0.1ms overhead**. We should try to get this down to <1ms. (https://github.com/JuliaPluto/Malt.jl/issues/24)