### PR TITLE
Use julia_cmd() instead of julia_exename()

### DIFF
--- a/src/Malt.jl
+++ b/src/Malt.jl
@@ -56,7 +56,7 @@ end
 
 const worker_script_path = RelocatableFolders.@path joinpath(@__DIR__, "worker.jl")
 
-function _get_worker_cmd(exe=joinpath(Sys.BINDIR, Base.julia_exename()); exeflags=[])
+function _get_worker_cmd(exe=Base.julia_cmd(); exeflags=[])
     `$exe $exeflags $worker_script_path`
 end
 


### PR DESCRIPTION
`Base.julia_exename()` is also not public API. @savq is there a specific reason to use `julia_exename()` here? What does Distributed use?