### PR TITLE
Disable startup-file by default

### DIFF
--- a/src/Malt.jl
+++ b/src/Malt.jl
@@ -55,7 +55,7 @@ end
 const worker_script_path = RelocatableFolders.@path(joinpath(@__DIR__, "worker.jl"))
 
 function _get_worker_cmd(exe=Base.julia_cmd()[1]; env, exeflags)
-    return addenv(`$exe $exeflags $worker_script_path`, Base.byteenv(env))
+    return addenv(`$exe --startup-file=no $exeflags $worker_script_path`, Base.byteenv(env))
 end
 
 _assert_is_running(w::Worker) = isrunning(w) || throw(TerminatedWorkerException())


### PR DESCRIPTION
Malt does not work if you have anything not using only Base in the
`startup.jl` file otherwise or in other cases (such as doing
`println(1234)`). This can still be re-enabled by using
`Malt.Worker(; exeflags=["--startup-file=yes"])`.
