### PR TITLE
Malt.stop tries everything to terminate the process

### DIFF
--- a/doc/src/index.md
+++ b/doc/src/index.md
@@ -88,7 +88,7 @@ the worker will also get a signal.
 ```@docs
 Malt.isrunning
 Malt.stop
-Malt.kill
+Base.kill(::Malt.Worker)
 Malt.interrupt
 Malt.TerminatedWorkerException
 ```

--- a/src/Malt.jl
+++ b/src/Malt.jl
@@ -521,7 +521,7 @@ end
 
 _wait_for_exit(::AbstractWorker; timeout_s::Real=20.0) = nothing
 function _wait_for_exit(w::Worker; timeout_s::Real=20.0)
-    if !poll(() -> !isrunning(w); timeout_s)
+    if !_poll(() -> !isrunning(w); timeout_s)
         error("HOST: Worker did not exit after $timeout_s seconds")
     end
 end

--- a/src/Malt.jl
+++ b/src/Malt.jl
@@ -171,7 +171,7 @@ function _receive_loop(worker::Worker)
                 sleep(3)
                 if isrunning(worker)
                     @error "HOST: Connection lost with worker, but the process is still running. Killing process..." exception = (e, catch_backtrace())
-                    kill(worker; signum=Base.SIGKILL)
+                    kill(worker, Base.SIGKILL)
                 else
                     # This is a clean exit
                 end
@@ -481,9 +481,9 @@ function stop(w::Worker)
     if isrunning(w)
         remote_do(Base.exit, w)
         if !_poll(ir; timeout_s=3.0)
-            kill(w; signum=Base.SIGTERM)
+            kill(w, Base.SIGTERM)
             if !_poll(ir; timeout_s=6.0)
-                kill(w; signum=Base.SIGKILL)
+                kill(w, Base.SIGKILL)
                 _wait_for_exit(w)
             end
         end
@@ -498,14 +498,14 @@ function stop(w::InProcessWorker)
 end
 
 """
-    Malt.kill(w::Worker; signum=Base.SIGTERM)
+    kill(w::Malt.Worker, signum=Base.SIGTERM)
 
 Terminate the worker process `w` forcefully by sending a `SIGTERM` signal (unless otherwise specified).
 
 This is not the recommended way to terminate the process. See `Malt.stop`.
 """ # https://youtu.be/dyIilW_eBjc
-kill(w::Worker; signum=Base.SIGTERM) = Base.kill(w.proc, signum)
-kill(::InProcessWorker; signum=Base.SIGTERM) = nothing
+Base.kill(w::Worker, signum=Base.SIGTERM) = Base.kill(w.proc, signum)
+Base.kill(::InProcessWorker, signum=Base.SIGTERM) = nothing
 
 
 function _poll(f::Function; interval::Real=0.01, timeout_s::Real=Inf64)

--- a/src/Malt.jl
+++ b/src/Malt.jl
@@ -171,7 +171,7 @@ function _receive_loop(worker::Worker)
                 sleep(3)
                 if isrunning(worker)
                     @error "HOST: Connection lost with worker, but the process is still running. Killing process..." exception = (e, catch_backtrace())
-                    kill(worker)
+                    kill(worker; signum=Base.SIGKILL)
                 else
                     # This is a clean exit
                 end
@@ -470,14 +470,23 @@ _assert_is_running(w::Worker) = isrunning(w) || throw(TerminatedWorkerException(
 """
     Malt.stop(w::Worker)::Bool
 
-Try to terminate the worker process `w` using `Base.exit`.
+Terminate the worker process `w` in the nicest possible way. We first try using `Base.exit`, then SIGTERM, then SIGKILL. Waits for the worker process to be terminated.
 
-If `w` is still alive, and a termination message is sent, `stop` returns true.
+If `w` is still alive, and now terinated, `stop` returns true.
 If `w` is already dead, `stop` returns `false`.
+If `w` failed to terminate, throw an exception.
 """
 function stop(w::Worker)
+    ir = () -> !isrunning(w)
     if isrunning(w)
         remote_do(Base.exit, w)
+        if !_poll(ir; timeout_s=3.0)
+            kill(w; signum=Base.SIGTERM)
+            if !_poll(ir; timeout_s=6.0)
+                kill(w; signum=Base.SIGKILL)
+                _wait_for_exit(w)
+            end
+        end
         true
     else
         false
@@ -489,24 +498,31 @@ function stop(w::InProcessWorker)
 end
 
 """
-    Malt.kill(w::Worker)
+    Malt.kill(w::Worker; signum=Base.SIGTERM)
 
-Terminate the worker process `w` forcefully by sending a `SIGTERM` signal.
+Terminate the worker process `w` forcefully by sending a `SIGTERM` signal (unless otherwise specified).
 
 This is not the recommended way to terminate the process. See `Malt.stop`.
 """ # https://youtu.be/dyIilW_eBjc
-kill(w::Worker) = Base.kill(w.proc)
-kill(::InProcessWorker) = nothing
+kill(w::Worker; signum=Base.SIGTERM) = Base.kill(w.proc, signum)
+kill(::InProcessWorker; signum=Base.SIGTERM) = nothing
 
 
-_wait_for_exit(::AbstractWorker; timeout_s::Real=20) = nothing
-function _wait_for_exit(w::Worker; timeout_s::Real=20)
-    t0 = time()
-    while isrunning(w)
-        sleep(0.01)
-        if time() - t0 > timeout_s
-            error("HOST: Worker did not exit after $timeout_s seconds")
+function _poll(f::Function; interval::Real=0.01, timeout_s::Real=Inf64)
+    tstart = time()
+    while true
+        f() && return true
+        if time() - tstart >= timeout_s
+            return false
         end
+        sleep(interval)
+    end
+end
+
+_wait_for_exit(::AbstractWorker; timeout_s::Real=20.0) = nothing
+function _wait_for_exit(w::Worker; timeout_s::Real=20.0)
+    if !poll(() -> !isrunning(w); timeout_s)
+        error("HOST: Worker did not exit after $timeout_s seconds")
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,7 +14,6 @@ using Test
 
         # Terminating workers takes about 0.5s
         m.stop(w)
-        m._wait_for_exit(w)
         @test m.isrunning(w) === false
     end
 
@@ -25,7 +24,6 @@ using Test
         @test m.remotecall_fetch(&, w, true, true)
 
         m.stop(w)
-        m._wait_for_exit(w)
     end
 
 
@@ -44,7 +42,6 @@ using Test
         @test m.remote_eval_fetch(Main, w, :(Stub.x)) == str
 
         m.stop(w)
-        m._wait_for_exit(w)
     end
 
 
@@ -106,9 +103,6 @@ using Test
         @test m.isrunning(w) === true
 
         m.stop(w)
-        # TODO: why do i need kill here?
-        m.kill(w)
-        m._wait_for_exit(w)
         @test m.isrunning(w) === false
     end
 
@@ -200,7 +194,7 @@ end
     @test m.isrunning(w)
 
     m.stop(w)
-    m._wait_for_exit(w)
+    @test !m.isrunning(w)
 end
 
 include("nesting.jl")


### PR DESCRIPTION
Replaces #21

This PR also removes `Malt.kill` and makes it an overload of `Base.kill` instead. Not a breaking change because Malt.kill will still work :)