### PR TITLE
Wrap remote exceptions in Malt.RemoteException

### DIFF
--- a/src/DistributedStdlibWorker.jl
+++ b/src/DistributedStdlibWorker.jl
@@ -94,9 +94,3 @@ function interrupt(w::DistributedStdlibWorker)
         Distributed.interrupt(w.pid)
     end
 end
-
-
-
-
-
-# TODO: wrap exceptions

--- a/src/DistributedStdlibWorker.jl
+++ b/src/DistributedStdlibWorker.jl
@@ -39,16 +39,28 @@ end
 Base.summary(io::IO, w::DistributedStdlibWorker) = write(io, "Malt.DistributedStdlibWorker with pid $(w.pid)")
 
 
+macro transform_exception(worker, ex)
+    :(try
+        $(esc(ex))
+    catch e
+        if e isa Distributed.RemoteException
+            throw($(RemoteException)($(esc(worker)), sprint(showerror, e.captured)))
+        else
+            rethrow(e)
+        end
+    end)
+end
+
 function remotecall(f, w::DistributedStdlibWorker, args...; kwargs...)
-    Distributed.remotecall(f, w.pid, args...; kwargs...)
+    @async Distributed.remotecall_fetch(f, w.pid, args...; kwargs...)
 end
 
 function remotecall_fetch(f, w::DistributedStdlibWorker, args...; kwargs...)
-    Distributed.remotecall_fetch(f, w.pid, args...; kwargs...)
+    @transform_exception w Distributed.remotecall_fetch(f, w.pid, args...; kwargs...)
 end
 
 function remotecall_wait(f, w::DistributedStdlibWorker, args...; kwargs...)
-    Distributed.remotecall_wait(f, w.pid, args...; kwargs...)
+    @transform_exception w Distributed.remotecall_wait(f, w.pid, args...; kwargs...)
     nothing
 end
 

--- a/src/Malt.jl
+++ b/src/Malt.jl
@@ -27,13 +27,29 @@ that has already been terminated.
 """
 struct TerminatedWorkerException <: Exception end
 
+struct RemoteException <: Exception
+    worker::AbstractWorker
+    message::String
+end
+
+function Base.showerror(io::IO, e::RemoteException)
+    print(io, "Remote exception from $(summary(e.worker)):\n\n$(e.message)")
+end
 
 struct WorkerResult
-    should_throw::Bool
+    msg_type::UInt8
     value::Any
 end
 
-unwrap_worker_result(result::WorkerResult) = result.should_throw ? throw(result.value) : result.value
+function unwrap_worker_result(worker::AbstractWorker, result::WorkerResult)
+    if result.msg_type == MsgType.special_serialization_failure
+        throw(ErrorException("Error deserializing data from $(summary(worker)):\n\n$(sprint(Base.showerror, result.value))"))
+    elseif result.msg_type == MsgType.from_worker_call_failure
+        throw(RemoteException(worker, result.value))
+    else
+        result.value
+    end
+end
 
 include("DistributedStdlibWorker.jl")
 
@@ -160,10 +176,7 @@ function _receive_loop(worker::Worker)
 
             c = get(worker.expected_replies, msg_id, nothing)
             if c isa Channel{WorkerResult}
-                put!(c, WorkerResult(
-                    msg_type == MsgType.special_serialization_failure,
-                    msg_data
-                ))
+                put!(c, WorkerResult(msg_type, msg_data))
             else
                 @error "HOST: Received a response, but I didn't ask for anything" msg_type msg_id msg_data
             end
@@ -267,7 +280,7 @@ function _wait_for_response(worker::Worker, msg_id::MsgID)
         @debug("HOST: waiting for response of", msg_id)
         response = take!(c)
         delete!(worker.expected_replies, msg_id)
-        return unwrap_worker_result(response)
+        return unwrap_worker_result(worker, response)
     else
         error("HOST: No response expected for message id $msg_id")
     end
@@ -320,11 +333,23 @@ function remotecall(f, w::Worker, args...; kwargs...)
     )
 end
 function remotecall(f, w::InProcessWorker, args...; kwargs...)
-    w.latest_request_task = @async try
+    w.latest_request_task = @async remotecall_fetch(f, w, args...; kwargs...)
+end
+function remotecall_fetch(f, w::InProcessWorker, args...; kwargs...)
+    try
         f(args...; kwargs...)
     catch ex
-        ex
+        throw(RemoteException(
+            w,
+            sprint() do io
+                Base.invokelatest(showerror, io, ex, catch_backtrace())
+            end
+        ))
     end
+end
+function remotecall_wait(f, w::InProcessWorker, args...; kwargs...)
+    remotecall_fetch(f, w, args...; kwargs...)
+    nothing
 end
 
 """

--- a/src/worker.jl
+++ b/src/worker.jl
@@ -121,7 +121,9 @@ function handle(::Val{MsgType.from_host_call_with_response}, socket, msg, msg_id
             (true, respond_with_nothing ? nothing : result)
         catch e
             # @debug("WORKER: Got exception!", e)
-            (false, e)
+            (false, sprint() do io
+                Base.invokelatest(showerror, io, e, catch_backtrace())
+            end)
         end
 
         _serialize_msg(

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -139,26 +139,4 @@
         m.stop(w)
         @test m.isrunning(w) === false
     end
-
-    (W === m.DistributedStdlibWorker) || @testset "Regular Exceptions" begin
-        w = W()
-
-        ## Mutually Known errors are not thrown, but returned as values.
-
-        @test isa(
-            m.remote_eval_fetch(Main, w, quote
-                sqrt(-1)
-            end),
-            DomainError,
-        )
-        @test m.remotecall_fetch(&, w, true, true)
-
-        @test isa(
-            m.remote_eval_fetch(Main, w, quote
-                error("Julia stack traces are bad. GL 😉")
-            end),
-            ErrorException,
-        )
-        @test m.remotecall_fetch(&, w, true, true)
-    end
 end

--- a/test/exceptions.jl
+++ b/test/exceptions.jl
@@ -37,7 +37,8 @@ end
             CallFailedException,
             m.remote_eval_wait(w, :(sqrt(-1))),
         )
-        @test_throws(
+        # searching for strings requires Julia 1.8
+        VERSION >= v"1.8.0" && @test_throws(
             ["Remote exception", "DomainError", "math.jl"],
             m.remote_eval_wait(w, :(sqrt(-1))),
         )
@@ -88,7 +89,8 @@ end
             CallFailedAndDeserializationOfExceptionFailedException,
             m.remote_eval_fetch(w, :(throw($stub_type_name2()))),
         )
-        @test_throws(
+        # searching for strings requires Julia 1.8
+        VERSION >= v"1.8.0" && @test_throws(
             ["Remote exception", W !== m.DistributedStdlibWorker ? "secretttzz" : "deseriali"],
             m.remote_eval_fetch(w, :(throw($stub_type_name2()))),
         )

--- a/test/exceptions.jl
+++ b/test/exceptions.jl
@@ -42,15 +42,10 @@ end
             ["Remote exception", "DomainError", "math.jl"],
             m.remote_eval_wait(w, :(sqrt(-1))),
         )
-        # TODO
-        # @test_throws(
-        #     m.RemoteException,
-        #     wait(m.remote_eval(w, :(sqrt(-1)))),
-        # )
-        # @test_throws(
-        #     TaskFailedException,
-        #     wait(m.remote_eval(w, :(sqrt(-1)))),
-        # )
+        @test_throws(
+            TaskFailedException,
+            wait(m.remote_eval(w, :(sqrt(-1)))),
+        )
         
         @test_nowarn m.remote_do(sqrt, w, -1)
         


### PR DESCRIPTION
Fix #31 

New type:

```julia
struct RemoteException <: Exception
    worker::AbstractWorker
    message::String
end
```

Example:

```julia
julia> Malt.remote_eval_fetch(m1, :(sqrt(-1)))
ERROR: Remote exception from Malt.Worker on port 9115:

DomainError with -1.0:
sqrt will only return a complex result if called with a complex argument. Try sqrt(Complex(x)).
Stacktrace:
 [1] throw_complex_domainerror(f::Symbol, x::Float64)
   @ Base.Math ./math.jl:33
 [2] sqrt
   @ ./math.jl:591 [inlined]
 [3] sqrt(x::Int64)
   @ Base.Math ./math.jl:1372
 [4] top-level scope
   @ none:1
 [5] eval
   @ ./boot.jl:368 [inlined]
 [6] macro expansion
   @ ~/Documents/Malt.jl/src/worker.jl:118 [inlined]
 [7] (::var"#1#3"{Sockets.TCPSocket, UInt64, Bool, Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}}, Tuple{Module, Expr}, typeof(Core.eval)})()
   @ Main ./task.jl:484
Stacktrace:
 [1] unwrap_worker_result(worker::Malt.Worker, result::Malt.WorkerResult)
   @ Malt ~/Documents/Malt.jl/src/Malt.jl:69
 [2] _wait_for_response(worker::Malt.Worker, msg_id::UInt64)
   @ Malt ~/Documents/Malt.jl/src/Malt.jl:304
 [3] _send_receive
   @ ~/Documents/Malt.jl/src/Malt.jl:315 [inlined]
 [4] #remotecall_fetch#41
   @ ~/Documents/Malt.jl/src/Malt.jl:385 [inlined]
 [5] remotecall_fetch
   @ ~/Documents/Malt.jl/src/Malt.jl:384 [inlined]
 [6] remote_eval_fetch
   @ ~/Documents/Malt.jl/src/Malt.jl:463 [inlined]
 [7] remote_eval_fetch(w::Malt.Worker, expr::Expr)
   @ Malt ~/Documents/Malt.jl/src/Malt.jl:464
 [8] top-level scope
   @ REPL[5]:1
```

This also helps to normalize the exception behaviour of the three backends.

# No original exception, only String

I decided to use a different API from Distributed. Distributed tries to serialize the original exception object and stacktrace, and it has a special error-failed-to-deserialize-flow for when this goes wrong (but then you don't see any info).

I think that this will occur too often with Malt use-cases (because Malt is for non-homogenous computing, so types are non shared), and I think a Maltonian program would write a specific try-catch handler on the worker end, and uncaught remote exceptions are only meant to be consumed by humans (so a string is fine).

So in Malt, we call `showerror` on the worker end to get the error message + stacktrace as a `String`, and this is what is returned to the host. This means that the error will always be visible to the host.

# New behaviour

Of all three worker types:

```julia
julia> import Malt

julia> m1 = Malt.Worker();

julia> m2 = Malt.InProcessWorker();

julia> m3 = Malt.DistributedStdlibWorker();

julia> Malt.remote_eval_fetch(m1, :(sqrt(-1)))
ERROR: Remote exception from Malt.Worker on port 9115:

DomainError with -1.0:
sqrt will only return a complex result if called with a complex argument. Try sqrt(Complex(x)).
Stacktrace:
 [1] throw_complex_domainerror(f::Symbol, x::Float64)
   @ Base.Math ./math.jl:33
 [2] sqrt
   @ ./math.jl:591 [inlined]
 [3] sqrt(x::Int64)
   @ Base.Math ./math.jl:1372
 [4] top-level scope
   @ none:1
 [5] eval
   @ ./boot.jl:368 [inlined]
 [6] macro expansion
   @ ~/Documents/Malt.jl/src/worker.jl:118 [inlined]
 [7] (::var"#1#3"{Sockets.TCPSocket, UInt64, Bool, Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}}, Tuple{Module, Expr}, typeof(Core.eval)})()
   @ Main ./task.jl:484
Stacktrace:
 [1] unwrap_worker_result(worker::Malt.Worker, result::Malt.WorkerResult)
   @ Malt ~/Documents/Malt.jl/src/Malt.jl:69
 [2] _wait_for_response(worker::Malt.Worker, msg_id::UInt64)
   @ Malt ~/Documents/Malt.jl/src/Malt.jl:304
 [3] _send_receive
   @ ~/Documents/Malt.jl/src/Malt.jl:315 [inlined]
 [4] #remotecall_fetch#41
   @ ~/Documents/Malt.jl/src/Malt.jl:385 [inlined]
 [5] remotecall_fetch
   @ ~/Documents/Malt.jl/src/Malt.jl:384 [inlined]
 [6] remote_eval_fetch
   @ ~/Documents/Malt.jl/src/Malt.jl:463 [inlined]
 [7] remote_eval_fetch(w::Malt.Worker, expr::Expr)
   @ Malt ~/Documents/Malt.jl/src/Malt.jl:464
 [8] top-level scope
   @ REPL[5]:1

julia> Malt.remote_eval_fetch(m2, :(sqrt(-1)))
ERROR: Remote exception from Malt.InProcessWorker in module Main:

DomainError with -1.0:
sqrt will only return a complex result if called with a complex argument. Try sqrt(Complex(x)).
Stacktrace:
  [1] throw_complex_domainerror(f::Symbol, x::Float64)
    @ Base.Math ./math.jl:33
  [2] sqrt
    @ ./math.jl:591 [inlined]
  [3] sqrt(x::Int64)
    @ Base.Math ./math.jl:1372
  [4] top-level scope
    @ none:1
  [5] eval(m::Module, e::Any)
    @ Core ./boot.jl:368
  [6] remotecall_fetch(::typeof(Core.eval), ::Malt.InProcessWorker, ::Module, ::Vararg{Any}; kwargs::Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
    @ Malt ~/Documents/Malt.jl/src/Malt.jl:361
  [7] remotecall_fetch
    @ ~/Documents/Malt.jl/src/Malt.jl:359 [inlined]
  [8] remote_eval_fetch
    @ ~/Documents/Malt.jl/src/Malt.jl:463 [inlined]
  [9] remote_eval_fetch(w::Malt.InProcessWorker, expr::Expr)
    @ Malt ~/Documents/Malt.jl/src/Malt.jl:464
 [10] top-level scope
    @ REPL[6]:1
 [11] eval
    @ ./boot.jl:368 [inlined]
 [12] eval_user_input(ast::Any, backend::REPL.REPLBackend)
    @ REPL /Applications/Julia-1.8 ARM.app/Contents/Resources/julia/share/julia/stdlib/v1.8/REPL/src/REPL.jl:151
 [13] repl_backend_loop(backend::REPL.REPLBackend)
    @ REPL /Applications/Julia-1.8 ARM.app/Contents/Resources/julia/share/julia/stdlib/v1.8/REPL/src/REPL.jl:247
 [14] start_repl_backend(backend::REPL.REPLBackend, consumer::Any)
    @ REPL /Applications/Julia-1.8 ARM.app/Contents/Resources/julia/share/julia/stdlib/v1.8/REPL/src/REPL.jl:232
 [15] run_repl(repl::REPL.AbstractREPL, consumer::Any; backend_on_current_task::Bool)
    @ REPL /Applications/Julia-1.8 ARM.app/Contents/Resources/julia/share/julia/stdlib/v1.8/REPL/src/REPL.jl:369
 [16] run_repl(repl::REPL.AbstractREPL, consumer::Any)
    @ REPL /Applications/Julia-1.8 ARM.app/Contents/Resources/julia/share/julia/stdlib/v1.8/REPL/src/REPL.jl:355
 [17] (::Base.var"#967#969"{Bool, Bool, Bool})(REPL::Module)
    @ Base ./client.jl:419
 [18] #invokelatest#2
    @ ./essentials.jl:729 [inlined]
 [19] invokelatest
    @ ./essentials.jl:726 [inlined]
 [20] run_main_repl(interactive::Bool, quiet::Bool, banner::Bool, history_file::Bool, color_set::Bool)
    @ Base ./client.jl:404
 [21] exec_options(opts::Base.JLOptions)
    @ Base ./client.jl:318
 [22] _start()
    @ Base ./client.jl:522
Stacktrace:
 [1] remotecall_fetch(::typeof(Core.eval), ::Malt.InProcessWorker, ::Module, ::Vararg{Any}; kwargs::Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
   @ Malt ~/Documents/Malt.jl/src/Malt.jl:363
 [2] remotecall_fetch
   @ ~/Documents/Malt.jl/src/Malt.jl:359 [inlined]
 [3] remote_eval_fetch
   @ ~/Documents/Malt.jl/src/Malt.jl:463 [inlined]
 [4] remote_eval_fetch(w::Malt.InProcessWorker, expr::Expr)
   @ Malt ~/Documents/Malt.jl/src/Malt.jl:464
 [5] top-level scope
   @ REPL[6]:1

caused by: DomainError with -1.0:
sqrt will only return a complex result if called with a complex argument. Try sqrt(Complex(x)).
Stacktrace:
  [1] throw_complex_domainerror(f::Symbol, x::Float64)
    @ Base.Math ./math.jl:33
  [2] sqrt
    @ ./math.jl:591 [inlined]
  [3] sqrt(x::Int64)
    @ Base.Math ./math.jl:1372
  [4] top-level scope
    @ none:1
  [5] eval(m::Module, e::Any)
    @ Core ./boot.jl:368
  [6] remotecall_fetch(::typeof(Core.eval), ::Malt.InProcessWorker, ::Module, ::Vararg{Any}; kwargs::Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
    @ Malt ~/Documents/Malt.jl/src/Malt.jl:361
  [7] remotecall_fetch
    @ ~/Documents/Malt.jl/src/Malt.jl:359 [inlined]
  [8] remote_eval_fetch
    @ ~/Documents/Malt.jl/src/Malt.jl:463 [inlined]
  [9] remote_eval_fetch(w::Malt.InProcessWorker, expr::Expr)
    @ Malt ~/Documents/Malt.jl/src/Malt.jl:464
 [10] top-level scope
    @ REPL[6]:1

julia> Malt.remote_eval_fetch(m3, :(sqrt(-1)))
ERROR: Remote exception from Malt.DistributedStdlibWorker with pid 2:

DomainError with -1.0:
sqrt will only return a complex result if called with a complex argument. Try sqrt(Complex(x)).
Stacktrace:
  [1] throw_complex_domainerror
    @ ./math.jl:33
  [2] sqrt
    @ ./math.jl:591 [inlined]
  [3] sqrt
    @ ./math.jl:1372
  [4] top-level scope
    @ none:1
  [5] eval
    @ ./boot.jl:368
  [6] #invokelatest#2
    @ ./essentials.jl:729
  [7] invokelatest
    @ ./essentials.jl:726
  [8] #110
    @ /Applications/Julia-1.8 ARM.app/Contents/Resources/julia/share/julia/stdlib/v1.8/Distributed/src/process_messages.jl:285
  [9] run_work_thunk
    @ /Applications/Julia-1.8 ARM.app/Contents/Resources/julia/share/julia/stdlib/v1.8/Distributed/src/process_messages.jl:70
 [10] macro expansion
    @ /Applications/Julia-1.8 ARM.app/Contents/Resources/julia/share/julia/stdlib/v1.8/Distributed/src/process_messages.jl:285 [inlined]
 [11] #109
    @ ./task.jl:484
Stacktrace:
 [1] remotecall_fetch(::Function, ::Malt.DistributedStdlibWorker, ::Module, ::Vararg{Any}; kwargs::Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
   @ Malt ~/Documents/Malt.jl/src/DistributedStdlibWorker.jl:47
 [2] remotecall_fetch
   @ ~/Documents/Malt.jl/src/DistributedStdlibWorker.jl:58 [inlined]
 [3] remote_eval_fetch
   @ ~/Documents/Malt.jl/src/Malt.jl:463 [inlined]
 [4] remote_eval_fetch(w::Malt.DistributedStdlibWorker, expr::Expr)
   @ Malt ~/Documents/Malt.jl/src/Malt.jl:464
 [5] top-level scope
   @ REPL[7]:1

caused by: On worker 2:
DomainError with -1.0:
sqrt will only return a complex result if called with a complex argument. Try sqrt(Complex(x)).
Stacktrace:
  [1] throw_complex_domainerror
    @ ./math.jl:33
  [2] sqrt
    @ ./math.jl:591 [inlined]
  [3] sqrt
    @ ./math.jl:1372
  [4] top-level scope
    @ none:1
  [5] eval
    @ ./boot.jl:368
  [6] #invokelatest#2
    @ ./essentials.jl:729
  [7] invokelatest
    @ ./essentials.jl:726
  [8] #110
    @ /Applications/Julia-1.8 ARM.app/Contents/Resources/julia/share/julia/stdlib/v1.8/Distributed/src/process_messages.jl:285
  [9] run_work_thunk
    @ /Applications/Julia-1.8 ARM.app/Contents/Resources/julia/share/julia/stdlib/v1.8/Distributed/src/process_messages.jl:70
 [10] macro expansion
    @ /Applications/Julia-1.8 ARM.app/Contents/Resources/julia/share/julia/stdlib/v1.8/Distributed/src/process_messages.jl:285 [inlined]
 [11] #109
    @ ./task.jl:484
Stacktrace:
 [1] remotecall_fetch(::Function, ::Distributed.Worker, ::Module, ::Vararg{Any}; kwargs::Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
   @ Distributed /Applications/Julia-1.8 ARM.app/Contents/Resources/julia/share/julia/stdlib/v1.8/Distributed/src/remotecall.jl:465
 [2] remotecall_fetch(::Function, ::Distributed.Worker, ::Module, ::Vararg{Any})
   @ Distributed /Applications/Julia-1.8 ARM.app/Contents/Resources/julia/share/julia/stdlib/v1.8/Distributed/src/remotecall.jl:454
 [3] remotecall_fetch(::Function, ::Int64, ::Module, ::Vararg{Any}; kwargs::Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
   @ Distributed /Applications/Julia-1.8 ARM.app/Contents/Resources/julia/share/julia/stdlib/v1.8/Distributed/src/remotecall.jl:492
 [4] remotecall_fetch(::Function, ::Int64, ::Module, ::Vararg{Any})
   @ Distributed /Applications/Julia-1.8 ARM.app/Contents/Resources/julia/share/julia/stdlib/v1.8/Distributed/src/remotecall.jl:492
 [5] remotecall_fetch(::Function, ::Malt.DistributedStdlibWorker, ::Module, ::Vararg{Any}; kwargs::Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
   @ Malt ~/Documents/Malt.jl/src/DistributedStdlibWorker.jl:44
 [6] remotecall_fetch
   @ ~/Documents/Malt.jl/src/DistributedStdlibWorker.jl:58 [inlined]
 [7] remote_eval_fetch
   @ ~/Documents/Malt.jl/src/Malt.jl:463 [inlined]
 [8] remote_eval_fetch(w::Malt.DistributedStdlibWorker, expr::Expr)
   @ Malt ~/Documents/Malt.jl/src/Malt.jl:464
 [9] top-level scope
   @ REPL[7]:1

```