### PR TITLE
Avoid infinite wait when process interrupted

### DIFF
--- a/src/shared.jl
+++ b/src/shared.jl
@@ -8,6 +8,7 @@ const MsgType = (
     from_worker_call_failure = UInt8(81),
     ###
     special_serialization_failure = UInt8(100),
+    special_worker_terminated = UInt8(101),
 )
 
 const MsgID = UInt64


### PR DESCRIPTION
Currently this will block indefinitely:

```julia
w = Malt.Worker()
task = Malt.remote_call(sleep, w, 10)
Malt.stop(w)
wait(task)
```

Fixed by this PR