### PR TITLE
Catch failure to open Worker and write out port

### DIFF
--- a/test/exceptions.jl
+++ b/test/exceptions.jl
@@ -149,6 +149,6 @@ struct LocalStruct end
 end
 
 @testset "Failure to spin up Worker" begin
-    e = @catcherror Malt.Worker(; exeflags = ["-t invalid"])
+    e = @catcherror m.Worker(; exeflags = ["-t invalid"])
     @test occursin("ERROR: julia: -t", e.msg)
 end

--- a/test/exceptions.jl
+++ b/test/exceptions.jl
@@ -147,3 +147,8 @@ struct LocalStruct end
     m.stop(w)
     @test !m.isrunning(w)
 end
+
+@testset "Failure to spin up Worker" begin
+    e = @catcherror Malt.Worker(; exeflags = ["-t invalid"])
+    @test occursin("ERROR: julia: -t", e.msg)
+end


### PR DESCRIPTION
We encountered a failure on CI where starting a Malt worker resulted in an obscure error. Something like:

```
julia> worker = Malt.Worker(; exeflags = ["-t invalid"])

ERROR: ArgumentError: input string is empty or only contains whitespace
Stacktrace:
 [1] tryparse_internal(::Type{UInt16}, s::String, startpos::Int64, endpos::Int64, base_::Int64, raise::Bool)
   @ Base ./parse.jl:115
 [2] parse(::Type{UInt16}, s::String; base::Nothing)
   @ Base ./parse.jl:254
 [3] parse
   @ ./parse.jl:253 [inlined]
 [4] Malt.Worker(; env::Vector{String}, exeflags::Vector{String})
   @ Malt ~/.julia/dev/Malt/src/Malt.jl:118
 [5] top-level scope
```

Turns out when a worker crashes before a port is written back, stdout is read back as `""` so you get an error when parsing that as the port number. But the underlying reason is not visible.

I tried here to read from stderr to report back what happened if reading the port fails. I didn't know off the top of my head how to do this more elegantly. I'm also not sure if `proc` could stall if the worker manages to start up correctly but then writes stuff there over time but nobody reads the pipe.

With this change you get this behavior on crashes:

```julia
julia> worker = Malt.Worker(; exeflags = ["-t invalid"])
ERROR: Failed to start worker process correctly. Expected to read port from stdout, got "" instead. Stderr output was:
ERROR: julia: -t,--threads=<n>[,auto|<m>]; n must be an integer >= 1

Stacktrace:
 [1] error(s::String)
   @ Base ./error.jl:35
 [2] Malt.Worker(; env::Vector{String}, exeflags::Vector{String})
   @ Malt ~/.julia/dev/Malt/src/Malt.jl:131
 [3] top-level scope
   @ REPL[34]:1
```

cc @MichaelHatherly 