### PR TITLE
Ignore EOFError during worker exit

### DIFF
--- a/src/Malt.jl
+++ b/src/Malt.jl
@@ -206,9 +206,13 @@ function _exit_loop(worker::Worker)
                 end
                 break
             end
-            sleep(1)
         catch e
             @error "Unexpected error encountered in the exit loop" worker exception = (e, catch_backtrace())
+        end
+        try
+            sleep(1)
+        catch e
+            e isa EOFError || rethrow(e)
         end
     end
 end


### PR DESCRIPTION
To hide error messages like this one in PlutoSliderServer

```
┌ Error: Unexpected error encountered in the exit loop
│   worker = Malt.Worker(0x25ba, Process(setenv(`/Users/fons/.julia/juliaup/julia-1.10.10+0.aarch64.apple.darwin14/bin/julia --startup-file=no --startup-file=no --history-file=no --threads=4 /Users/fons/.julia/packages/Malt/bAS4Y/src/worker.jl`,["XPC_FLAGS=0x0", "LSCOLORS=Gxfxcxdxbxegedabagacad", "PATH=/Users/fons/.nvm/versions/node/v22.14.0/bin:/Users/fons/.juliaup/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Users/fons/.deno/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/Library/TeX/texbin:/usr/local/share/dotnet:~/.dotnet/tools:/usr/local/sbin", "PWD=/Users/fons", "XPC_SERVICE_NAME=0", "TERM_PROGRAM=Apple_Terminal", "SHELL=/bin/zsh", "__CF_USER_TEXT_ENCODING=0x1F5:0x0:0x5", "OPENBLAS_NUM_THREADS=1", "OSLogRateLimit=64"  …  "SECURITYSESSIONID=186af", "USER=fons", "JULIA_DEBUG=PlutoSliderServer", "TERM=xterm-256color", "HOME=/Users/fons", "TERM_PROGRAM_VERSION=464", "OPENBLAS_MAIN_FREE=1", "COLORTERM=truecolor", "LESS=-R", "ZSH=/Users/fons/.oh-my-zsh"]), ProcessExited(0)), 29658, Sockets.TCPSocket(RawFD(60) eof, 0 bytes waiting), 0x000000000000008b, Dict{UInt64, Channel{Malt.WorkerResult}}(0x0000000000000002 => Channel{Malt.WorkerResult}(1), 0x000000000000000b => Channel{Malt.WorkerResult}(1), 0x000000000000000c => Channel{Malt.WorkerResult}(1)), Pipe(RawFD(54) open => RawFD(53) active, 0 bytes waiting), Pipe(RawFD(23) open => RawFD(21) active, 0 bytes waiting))
│   exception =
│    EOFError: read end of file
│    Stacktrace:
│     [1] wait
│       @ ./asyncevent.jl:159 [inlined]
│     [2] sleep
│       @ ./asyncevent.jl:265 [inlined]
│     [3] (::Malt.var"#33#34"{Malt.Worker})()
│       @ Malt ~/.julia/packages/Malt/bAS4Y/src/Malt.jl:209
└ @ Malt ~/.julia/packages/Malt/bAS4Y/src/Malt.jl:211
EOFError: read end of file
```