### PR TITLE
Add option to customize the exename

### DIFF
--- a/src/Malt.jl
+++ b/src/Malt.jl
@@ -102,9 +102,9 @@ mutable struct Worker <: AbstractWorker
 
     stdout::Pipe
     stderr::Pipe
-    function Worker(; env=String[], exeflags=[])
+    function Worker(; env=String[], exename=exe=Base.julia_cmd()[1], exeflags=[])
         # Spawn process
-        cmd = _get_worker_cmd(; env, exeflags)
+        cmd = _get_worker_cmd(exename; env, exeflags)
         _stdout = Pipe()
         _stderr = Pipe()
         proc = run(


### PR DESCRIPTION
We are currently investigating using Malt.jl for ParallelTestRunner.jl (https://github.com/JuliaTesting/ParallelTestRunner.jl/pull/48) and for some advanced use-cases we would need to be able to change the exename being launched.


