### PR TITLE
Add `monitor_std{out,err}` arguments to Worker constructor

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Malt"
 uuid = "36869731-bdee-424d-aa32-cab38c994e3b"
 authors = ["Sergio Alejandro Vargas <savargasqu+git@unal.edu.co>", "Fons van der Plas <fons@plutojl.org>"]
-version = "1.3.1"
+version = "1.4.0"
 
 [deps]
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"

--- a/src/Malt.jl
+++ b/src/Malt.jl
@@ -88,6 +88,13 @@ Create a new `Worker`. A `Worker` struct is a handle to a (separate) Julia proce
 julia> w = Malt.Worker()
 Malt.Worker(0x0000, Process(`…`, ProcessRunning))
 ```
+
+# Keyword arguments
+- `env::Vector{String}`: Environment variables to set in the worker process.
+- `exename::String`: Path to the Julia executable to use for the worker process.
+- `exeflags::Vector{String}`: Additional command-line flags to pass to the Julia executable.
+- `monitor_stdout::Bool=true`: Whether to print the stdout of the worker process to the main process's stdout. When set to `false`, you can access the stdout `Pipe` via the `worker.stdout` field after creation.
+- `monitor_stderr::Bool=true`: Same for `stderr`.
 """
 mutable struct Worker <: AbstractWorker
     port::UInt16
@@ -101,25 +108,17 @@ mutable struct Worker <: AbstractWorker
     expected_replies::Dict{MsgID,Channel{WorkerResult}}
 
     # Pipes used for collecting the stdout/stderr of the process
-    stdout_pipe::Pipe
-    stderr_pipe::Pipe
-    # IOs the streams are written to
-    collected_stdout::IO
-    collected_stderr::IO
-
+    stdout::Pipe
+    stderr::Pipe    
+    
     function Worker(
         ;
         env=String[],
         exename=Base.julia_cmd()[1],
         exeflags=[],
-        stdout=Base.stdout,
-        stderr=Base.stderr,
-        stop=stop,
-        stdio_loop=_stdio_loop,
-        exit_loop=_exit_loop,
-        receive_loop=_receive_loop,
+        monitor_stdout::Bool=true,
+        monitor_stderr::Bool=true,
         )
-
         # Spawn process
         cmd = _get_worker_cmd(exename; env, exeflags)
         _stdout = Pipe()
@@ -170,15 +169,13 @@ mutable struct Worker <: AbstractWorker
                 MsgID(0),
                 Dict{MsgID,Channel{WorkerResult}}(),
                 _stdout,
-                _stderr,
-                stdout,
-                stderr,
+                _stderr
             )
         )
         atexit(() -> stop(w))
-        stdio_loop(w)
-        exit_loop(w)
-        receive_loop(w)
+        _stdio_loop(w; monitor_stdout, monitor_stderr)
+        _exit_loop(w)
+        _receive_loop(w)
 
         return w
     end
@@ -202,25 +199,25 @@ end
 
 Base.summary(io::IO, w::Worker) = write(io, "Malt.Worker on port $(w.port) with PID $(w.proc_pid)")
 
-function _stdio_loop(worker::Worker)
-    @async while isopen(worker.stdout_pipe) && isrunning(worker)
+function _stdio_loop(worker::Worker; monitor_stdout::Bool, monitor_stderr::Bool)
+    monitor_stdout && @async while isopen(worker.stdout) && isrunning(worker)
         try
-            bytes = readline(worker.stdout_pipe)
+            bytes = readline(worker.stdout)
             c = get(stdout, :color, false) === true
             prefix = c ? "\e[34m[Worker $(worker.proc_pid)]:\e[39m " : "[Worker $(worker.proc_pid)]: "
-            write(worker.collected_stdout, prefix, bytes, '\n')
-            flush(worker.collected_stdout)
+            write(stdout, prefix, bytes, '\n')
+            flush(stdout)
         catch
             break
         end
     end
-    @async while isopen(worker.stderr_pipe) && isrunning(worker)
+    monitor_stderr && @async while isopen(worker.stderr) && isrunning(worker)
         try
-            bytes = readline(worker.stderr_pipe)
+            bytes = readline(worker.stderr)
             c = get(stderr, :color, false) === true
             prefix = c ? "\e[33m[Worker $(worker.proc_pid)]:\e[39m " : "[Worker $(worker.proc_pid)]: "
-            write(worker.collected_stderr, prefix, bytes, '\n')
-            flush(worker.collected_stderr)
+            write(stderr, prefix, bytes, '\n')
+            flush(stderr)
         catch
             break
         end

--- a/src/Malt.jl
+++ b/src/Malt.jl
@@ -102,7 +102,17 @@ mutable struct Worker <: AbstractWorker
 
     stdout::Pipe
     stderr::Pipe
-    function Worker(; env=String[], exename=Base.julia_cmd()[1], exeflags=[])
+    function Worker(
+        ;
+        env=String[],
+        exename=Base.julia_cmd()[1],
+        exeflags=[],
+        stop=stop,
+        stdio_loop=_stdio_loop,
+        exit_loop=_exit_loop,
+        receive_loop=_receive_loop,
+        )
+
         # Spawn process
         cmd = _get_worker_cmd(exename; env, exeflags)
         _stdout = Pipe()
@@ -157,9 +167,9 @@ mutable struct Worker <: AbstractWorker
             )
         )
         atexit(() -> stop(w))
-        _stdio_loop(w)
-        _exit_loop(w)
-        _receive_loop(w)
+        stdio_loop(w)
+        exit_loop(w)
+        receive_loop(w)
 
         return w
     end

--- a/src/Malt.jl
+++ b/src/Malt.jl
@@ -100,13 +100,20 @@ mutable struct Worker <: AbstractWorker
     current_message_id::MsgID
     expected_replies::Dict{MsgID,Channel{WorkerResult}}
 
-    stdout::Pipe
-    stderr::Pipe
+    # Pipes used for collecting the stdout/stderr of the process
+    stdout_pipe::Pipe
+    stderr_pipe::Pipe
+    # IOs the streams are written to
+    collected_stdout::IO
+    collected_stderr::IO
+
     function Worker(
         ;
         env=String[],
         exename=Base.julia_cmd()[1],
         exeflags=[],
+        stdout=Base.stdout,
+        stderr=Base.stderr,
         stop=stop,
         stdio_loop=_stdio_loop,
         exit_loop=_exit_loop,
@@ -163,7 +170,9 @@ mutable struct Worker <: AbstractWorker
                 MsgID(0),
                 Dict{MsgID,Channel{WorkerResult}}(),
                 _stdout,
-                _stderr
+                _stderr,
+                stdout,
+                stderr,
             )
         )
         atexit(() -> stop(w))
@@ -194,24 +203,24 @@ end
 Base.summary(io::IO, w::Worker) = write(io, "Malt.Worker on port $(w.port) with PID $(w.proc_pid)")
 
 function _stdio_loop(worker::Worker)
-    @async while isopen(worker.stdout) && isrunning(worker)
+    @async while isopen(worker.stdout_pipe) && isrunning(worker)
         try
-            bytes = readline(worker.stdout)
+            bytes = readline(worker.stdout_pipe)
             c = get(stdout, :color, false) === true
             prefix = c ? "\e[34m[Worker $(worker.proc_pid)]:\e[39m " : "[Worker $(worker.proc_pid)]: "
-            write(stdout, prefix, bytes, '\n')
-            flush(stdout)
+            write(worker.collected_stdout, prefix, bytes, '\n')
+            flush(worker.collected_stdout)
         catch
             break
         end
     end
-    @async while isopen(worker.stderr) && isrunning(worker)
+    @async while isopen(worker.stderr_pipe) && isrunning(worker)
         try
-            bytes = readline(worker.stderr)
+            bytes = readline(worker.stderr_pipe)
             c = get(stderr, :color, false) === true
             prefix = c ? "\e[33m[Worker $(worker.proc_pid)]:\e[39m " : "[Worker $(worker.proc_pid)]: "
-            write(stderr, prefix, bytes, '\n')
-            flush(stderr)
+            write(worker.collected_stderr, prefix, bytes, '\n')
+            flush(worker.collected_stderr)
         catch
             break
         end

--- a/src/Malt.jl
+++ b/src/Malt.jl
@@ -109,7 +109,7 @@ mutable struct Worker <: AbstractWorker
 
     # Pipes used for collecting the stdout/stderr of the process
     stdout::Pipe
-    stderr::Pipe    
+    stderr::Pipe
     
     function Worker(
         ;

--- a/test/stdout.jl
+++ b/test/stdout.jl
@@ -34,3 +34,33 @@ using IOCapture
     
     m.stop(w)
 end
+
+@testset "Stdout & stderr custom pipe" begin
+    w = m.Worker(; monitor_stdout=false, monitor_stderr=true)
+    
+    cap(expr) = IOCapture.capture(color=true) do
+        m.remote_eval_wait(w, expr)
+        sleep(0.1)
+    end.output
+    
+    blue = "\e[34m"
+    yellow = "\e[33m"
+    reset = "\e[39m"
+    
+    s = cap(:(println("hallootjes")))
+    @test s == ""
+    
+    s = cap(:(println(stderr, "hello")))
+    @test occursin("hello", s)
+    @test !occursin(blue, s)
+    @test occursin(yellow, s)
+    @test 1 <= count("\n", s) <= 2
+    
+    # Now I should be able to read the `stdout` pipe manually
+    pipe_contents = Base.readavailable(w.stdout) |> String
+    @test occursin("hallootjes", pipe_contents)
+    @test !occursin(blue, pipe_contents)
+    @test !occursin(yellow, pipe_contents)
+    
+    m.stop(w)
+end


### PR DESCRIPTION
Note: only the first commit (5e1f43e) is strictly necessary (well, also bumping the version number, 374af84), but adding the fields for the stdout/stderr IOs greatly simplifies the code for downstream users, who don't need to capture the IO object in a closure to pass as `stdio_loop`, so being able to keep 6daa042 would be greatly welcome for ParallelTestRunner.jl.  However I'll point out that the fields `collected_stdout`/`collected_stderr` are ***not*** concrete.

This implementation should retain existing behaviour (unless I missed something), the purpose is only to add the ability for the users to pass custom arguments to the `Worker` constructor.

Fix #102.