### PR TITLE
Make accesses to `__iNtErNaL_running_procs` thread-safe

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Malt"
 uuid = "36869731-bdee-424d-aa32-cab38c994e3b"
 authors = ["Sergio Alejandro Vargas <savargasqu+git@unal.edu.co>", "Fons van der Plas <fons@plutojl.org>"]
-version = "1.4.0"
+version = "1.4.1"
 
 [deps]
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"

--- a/src/Malt.jl
+++ b/src/Malt.jl
@@ -75,7 +75,8 @@ end
 Base.summary(io::IO, w::InProcessWorker) = write(io, "Malt.InProcessWorker in module $(w.host_module)")
 
 const __iNtErNaL_running_procs = Set{Base.Process}()
-__iNtErNaL_get_running_procs() = filter!(Base.process_running, __iNtErNaL_running_procs)
+const procs_lock = ReentrantLock()
+__iNtErNaL_get_running_procs() = Base.@lock procs_lock filter!(Base.process_running, __iNtErNaL_running_procs)
 
 """
     Malt.Worker()
@@ -134,7 +135,7 @@ mutable struct Worker <: AbstractWorker
 
         # Keep internal list
         __iNtErNaL_get_running_procs()
-        push!(__iNtErNaL_running_procs, proc)
+        Base.@lock procs_lock push!(__iNtErNaL_running_procs, proc)
 
         yield() # https://github.com/fonsp/Pluto.jl/issues/3423
 


### PR DESCRIPTION
`__iNtErNaL_running_procs` is a global state, and in a multi-threaded scenario it's unsafe to directly `push!` to it.  A simple lock around it solves the issue.  Without this, I got occasional
```
  Got exception outside of a @test
  TaskFailedException
      nested task error: AssertionError: Multiple concurrent writes to Dict detected!
      Stacktrace:
        [1] rehash!(h::Dict{Base.Process, Nothing}, newsz::Int64)
          @ Base ./dict.jl:183
        [2] ht_keyindex2_shorthash!(h::Dict{Base.Process, Nothing}, key::Base.Process)
          @ Base ./dict.jl:270
        [3] setindex!(h::Dict{Base.Process, Nothing}, v0::Nothing, key::Base.Process)
          @ Base ./dict.jl:358
        [4] push!
          @ ./set.jl:137 [inlined]
        [5] Malt.Worker(; env::Vector{Pair{String, String}}, exename::String, exeflags::Vector{String}, monitor_stdout::Bool, monitor_stderr::Bool)
          @ Malt ~/.julia/packages/Malt/yA40d/src/Malt.jl:137
        [6] Worker
          @ ~/.julia/packages/Malt/yA40d/src/Malt.jl:114 [inlined]
```