### PR TITLE
Fix tests in stable versions of Julia

### DIFF
--- a/test/starting.jl
+++ b/test/starting.jl
@@ -3,10 +3,14 @@
 @testset "Starting exceptions" begin
     # Searching for strings requires Julia 1.8
     needle = VERSION >= v"1.8.0" ? ["exited before we could connect", "threads"] : ErrorException
-    
+
     tstart = time()
     @test_throws needle m.Worker(; exeflags = ["-t invalid"])
     tend = time()
-    
-    @test tend - tstart < 15.0
+
+    # When we create a worker we start a timedwait (currently of 30 seconds), trying to
+    # connect to it.  When the Julia process is launched with invalid arguments, the poll
+    # will time out because it'll fail to connect to it.  Here we check that the whole
+    # process took a reasonable time around 30 seconds.
+    @test 25.0 < tend - tstart < 40.0
 end


### PR DESCRIPTION
I believe this was simply broken by #99 by changing the timeout interval.  Tests pass locally for me in Julia v1.10-v1.12 (the only versions I tested), so at least this should restore some greenness in CI.  CC @pankgeorg 